### PR TITLE
Use QStringLiteral and spelling fix

### DIFF
--- a/DarkStyle.cpp
+++ b/DarkStyle.cpp
@@ -9,7 +9,7 @@ DarkStyle::DarkStyle(QStyle *style):
 { }
 
 QStyle *DarkStyle::styleBase(QStyle *style) const {
-    static QStyle *base = !style ? QStyleFactory::create("Fusion") : style;
+    static QStyle *base = !style ? QStyleFactory::create(QStringLiteral("Fusion")) : style;
     return base;
 }
 
@@ -53,12 +53,12 @@ void DarkStyle::polish(QApplication *app)
     defaultFont.setPointSize(defaultFont.pointSize()+1);
     app->setFont(defaultFont);
 
-    // loadstylesheet    
-    QFile qfDarkstyle(QString(":/darkstyle/darkstyle.qss"));
+    // loadstylesheet
+    QFile qfDarkstyle(QStringLiteral(":/darkstyle/darkstyle.qss"));
     if (qfDarkstyle.open(QIODevice::ReadOnly | QIODevice::Text))
     {
         // set stylesheet
-        QString qsStylesheet = QString(qfDarkstyle.readAll());
+        QString qsStylesheet = QString::fromLatin1(qfDarkstyle.readAll());
         app->setStyleSheet(qsStylesheet);
         qfDarkstyle.close();
     }

--- a/framelesswindow/framelesswindow.cpp
+++ b/framelesswindow/framelesswindow.cpp
@@ -76,8 +76,8 @@ void FramelessWindow::styleWindow(bool bActive, bool bNoState)
   if (bActive) {
     if (bNoState) {
       layout()->setMargin(15);
-      windowTitlebar->setStyleSheet("#windowTitlebar{border: 0px none palette(shadow); border-top-left-radius:5px; border-top-right-radius:5px; background-color:palette(shadow); height:20px;}");
-      windowFrame->setStyleSheet("#windowFrame{border:1px solid palette(highlight); border-radius:5px 5px 5px 5px; background-color:palette(Window);}");
+      windowTitlebar->setStyleSheet(QStringLiteral("#windowTitlebar{border: 0px none palette(shadow); border-top-left-radius:5px; border-top-right-radius:5px; background-color:palette(shadow); height:20px;}"));
+      windowFrame->setStyleSheet(QStringLiteral("#windowFrame{border:1px solid palette(highlight); border-radius:5px 5px 5px 5px; background-color:palette(Window);}"));
       QGraphicsEffect *oldShadow = windowFrame->graphicsEffect();
       if (oldShadow)
         delete oldShadow;
@@ -88,8 +88,8 @@ void FramelessWindow::styleWindow(bool bActive, bool bNoState)
       windowFrame->setGraphicsEffect(windowShadow);
     } else {
       layout()->setMargin(0);
-      windowTitlebar->setStyleSheet("#windowTitlebar{border: 0px none palette(shadow); border-top-left-radius:0px; border-top-right-radius:0px; background-color:palette(shadow); height:20px;}");
-      windowFrame->setStyleSheet("#windowFrame{border:1px solid palette(dark); border-radius:0px 0px 0px 0px; background-color:palette(Window);}");
+      windowTitlebar->setStyleSheet(QStringLiteral("#windowTitlebar{border: 0px none palette(shadow); border-top-left-radius:0px; border-top-right-radius:0px; background-color:palette(shadow); height:20px;}"));
+      windowFrame->setStyleSheet(QStringLiteral("#windowFrame{border:1px solid palette(dark); border-radius:0px 0px 0px 0px; background-color:palette(Window);}"));
       QGraphicsEffect *oldShadow = windowFrame->graphicsEffect();
       if (oldShadow)
         delete oldShadow;
@@ -98,8 +98,8 @@ void FramelessWindow::styleWindow(bool bActive, bool bNoState)
   } else {
     if (bNoState) {
       layout()->setMargin(15);
-      windowTitlebar->setStyleSheet("#windowTitlebar{border: 0px none palette(shadow); border-top-left-radius:5px; border-top-right-radius:5px; background-color:palette(dark); height:20px;}");
-      windowFrame->setStyleSheet("#windowFrame{border:1px solid #000000; border-radius:5px 5px 5px 5px; background-color:palette(Window);}");
+      windowTitlebar->setStyleSheet(QStringLiteral("#windowTitlebar{border: 0px none palette(shadow); border-top-left-radius:5px; border-top-right-radius:5px; background-color:palette(dark); height:20px;}"));
+      windowFrame->setStyleSheet(QStringLiteral("#windowFrame{border:1px solid #000000; border-radius:5px 5px 5px 5px; background-color:palette(Window);}"));
       QGraphicsEffect *oldShadow = windowFrame->graphicsEffect();
       if (oldShadow)
         delete oldShadow;
@@ -110,8 +110,8 @@ void FramelessWindow::styleWindow(bool bActive, bool bNoState)
       windowFrame->setGraphicsEffect(windowShadow);
     } else {
       layout()->setMargin(0);
-      windowTitlebar->setStyleSheet("#titlebarWidget{border: 0px none palette(shadow); border-top-left-radius:0px; border-top-right-radius:0px; background-color:palette(dark); height:20px;}");
-      windowFrame->setStyleSheet("#windowFrame{border:1px solid palette(shadow); border-radius:0px 0px 0px 0px; background-color:palette(Window);}");
+      windowTitlebar->setStyleSheet(QStringLiteral("#titlebarWidget{border: 0px none palette(shadow); border-top-left-radius:0px; border-top-right-radius:0px; background-color:palette(dark); height:20px;}"));
+      windowFrame->setStyleSheet(QStringLiteral("#windowFrame{border:1px solid palette(shadow); border-radius:0px 0px 0px 0px; background-color:palette(Window);}"));
       QGraphicsEffect *oldShadow = windowFrame->graphicsEffect();
       if (oldShadow)
         delete oldShadow;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -59,7 +59,7 @@
       <item>
        <widget class="QCheckBox" name="checkBox_4">
         <property name="text">
-         <string>Disbale Widgets</string>
+         <string>Disable Widgets</string>
         </property>
         <property name="checked">
          <bool>false</bool>


### PR DESCRIPTION
My project uses `QT_NO_CAST_FROM_ASCII` and `QT_NO_CAST_TO_ASCII` as defines which makes sure no implicit casts to `QString` will happen. Implicit casts will create additional memory allocations and by using `QStringLiteral(...)` these allocation can be prevented and with the defines above the code simply won't compile. This PR changes the code to use `QStringLiteral` for these case.

I also fixed a typo -> `Disbale` -> `Disable`