### PR TITLE
fix: border can't resize when framelesswindows in a parent widget

### DIFF
--- a/framelesswindow/framelesswindow.cpp
+++ b/framelesswindow/framelesswindow.cpp
@@ -228,12 +228,12 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
       w = sz.width();
     }
 
+    QPoint widgetGlobalPos = parentWidget()->mapToGlobal(QPoint(m_StartGeometry.x(), m_StartGeometry.y()));
     // top right corner
     if (m_bDragTop && m_bDragRight) {
-      int diff =
-          globalMousePos.x() - (m_StartGeometry.x() + m_StartGeometry.width());
+      int diff = globalMousePos.x() - (widgetGlobalPos.x() + m_StartGeometry.width());
       int neww = m_StartGeometry.width() + diff;
-      diff = globalMousePos.y() - m_StartGeometry.y();
+      diff = globalMousePos.y() - widgetGlobalPos.y();
       int newy = m_StartGeometry.y() + diff;
       if (neww > 0 && newy > 0 && newy < h - 50) {
         QRect newg = m_StartGeometry;
@@ -245,9 +245,9 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
     }
     // top left corner
     else if (m_bDragTop && m_bDragLeft) {
-      int diff = globalMousePos.y() - m_StartGeometry.y();
+      int diff = globalMousePos.y() - widgetGlobalPos.y();
       int newy = m_StartGeometry.y() + diff;
-      diff = globalMousePos.x() - m_StartGeometry.x();
+      diff = globalMousePos.x() - widgetGlobalPos.x();
       int newx = m_StartGeometry.x() + diff;
       if (newy > 0 && newx > 0) {
         QRect newg = m_StartGeometry;
@@ -258,10 +258,9 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
     }
     // bottom right corner
     else if (m_bDragBottom && m_bDragLeft) {
-      int diff =
-          globalMousePos.y() - (m_StartGeometry.y() + m_StartGeometry.height());
+      int diff = globalMousePos.y() - (widgetGlobalPos.y() + m_StartGeometry.height());
       int newh = m_StartGeometry.height() + diff;
-      diff = globalMousePos.x() - m_StartGeometry.x();
+      diff = globalMousePos.x() - widgetGlobalPos.x();
       int newx = m_StartGeometry.x() + diff;
       if (newh > 0 && newx > 0) {
         QRect newg = m_StartGeometry;
@@ -270,7 +269,7 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
         setGeometry(newg);
       }
     } else if (m_bDragTop) {
-      int diff = globalMousePos.y() - m_StartGeometry.y();
+      int diff = globalMousePos.y() - widgetGlobalPos.y();
       int newy = m_StartGeometry.y() + diff;
       if (newy > 0 && newy < h - 50) {
         QRect newg = m_StartGeometry;
@@ -278,7 +277,7 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
         setGeometry(newg);
       }
     } else if (m_bDragLeft) {
-      int diff = globalMousePos.x() - m_StartGeometry.x();
+      int diff = globalMousePos.x() - widgetGlobalPos.x();
       int newx = m_StartGeometry.x() + diff;
       if (newx > 0 && newx < w - 50) {
         QRect newg = m_StartGeometry;
@@ -287,7 +286,7 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
       }
     } else if (m_bDragRight) {
       int diff =
-          globalMousePos.x() - (m_StartGeometry.x() + m_StartGeometry.width());
+          globalMousePos.x() - (widgetGlobalPos.x() + m_StartGeometry.width());
       int neww = m_StartGeometry.width() + diff;
       if (neww > 0) {
         QRect newg = m_StartGeometry;
@@ -297,7 +296,7 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
       }
     } else if (m_bDragBottom) {
       int diff =
-          globalMousePos.y() - (m_StartGeometry.y() + m_StartGeometry.height());
+          globalMousePos.y() - (widgetGlobalPos.y() + m_StartGeometry.height());
       int newh = m_StartGeometry.height() + diff;
       if (newh > 0) {
         QRect newg = m_StartGeometry;
@@ -338,7 +337,8 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
 // pos in global virtual desktop coordinates
 bool FramelessWindow::leftBorderHit(const QPoint &pos) {
   const QRect &rect = this->geometry();
-  if (pos.x() >= rect.x() && pos.x() <= rect.x() + CONST_DRAG_BORDER_SIZE) {
+  QPoint gp = parentWidget()->mapToGlobal(QPoint(rect.x(), rect.y()));
+  if (pos.x() >= gp.x() && pos.x() <= gp.x() + CONST_DRAG_BORDER_SIZE) {
     return true;
   }
   return false;
@@ -346,7 +346,8 @@ bool FramelessWindow::leftBorderHit(const QPoint &pos) {
 
 bool FramelessWindow::rightBorderHit(const QPoint &pos) {
   const QRect &rect = this->geometry();
-  int tmp = rect.x() + rect.width();
+  QPoint gp = parentWidget()->mapToGlobal(QPoint(rect.x(), rect.y()));
+  int tmp = gp.x() + rect.width();
   if (pos.x() <= tmp && pos.x() >= (tmp - CONST_DRAG_BORDER_SIZE)) {
     return true;
   }
@@ -355,7 +356,9 @@ bool FramelessWindow::rightBorderHit(const QPoint &pos) {
 
 bool FramelessWindow::topBorderHit(const QPoint &pos) {
   const QRect &rect = this->geometry();
-  if (pos.y() >= rect.y() && pos.y() <= rect.y() + CONST_DRAG_BORDER_SIZE) {
+  QPoint gp = parentWidget()->mapToGlobal(QPoint(rect.x(), rect.y()));
+
+  if (pos.y() >= gp.y() && pos.y() <= gp.y() + CONST_DRAG_BORDER_SIZE) {
     return true;
   }
   return false;
@@ -363,7 +366,9 @@ bool FramelessWindow::topBorderHit(const QPoint &pos) {
 
 bool FramelessWindow::bottomBorderHit(const QPoint &pos) {
   const QRect &rect = this->geometry();
-  int tmp = rect.y() + rect.height();
+  QPoint gp = parentWidget()->mapToGlobal(QPoint(rect.x(), rect.y()));
+
+  int tmp = gp.y() + rect.height();
   if (pos.y() <= tmp && pos.y() >= (tmp - CONST_DRAG_BORDER_SIZE)) {
     return true;
   }

--- a/framelesswindow/framelesswindow.cpp
+++ b/framelesswindow/framelesswindow.cpp
@@ -256,7 +256,7 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
         setGeometry(newg);
       }
     }
-    // bottom right corner
+    // bottom left corner
     else if (m_bDragBottom && m_bDragLeft) {
       int diff = globalMousePos.y() - (widgetGlobalPos.y() + m_StartGeometry.height());
       int newh = m_StartGeometry.height() + diff;
@@ -268,7 +268,23 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
         newg.setHeight(newh);
         setGeometry(newg);
       }
-    } else if (m_bDragTop) {
+    }
+    // bottom right corner
+    else if (m_bDragBottom && m_bDragRight) {
+        int diff = globalMousePos.y() - (widgetGlobalPos.y() + m_StartGeometry.height());
+        int newh = m_StartGeometry.height() + diff;
+
+        diff = globalMousePos.x() - (widgetGlobalPos.x() + m_StartGeometry.width());
+        int neww = m_StartGeometry.width() + diff;
+
+        if (newh > 0 && neww > 0) {
+            QRect newg = m_StartGeometry;
+            newg.setWidth(neww);
+            newg.setHeight(newh);
+            setGeometry(newg);
+        }
+    }
+    else if (m_bDragTop) {
       int diff = globalMousePos.y() - widgetGlobalPos.y();
       int newy = m_StartGeometry.y() + diff;
       if (newy > 0 && newy < h - 50) {
@@ -311,10 +327,11 @@ void FramelessWindow::checkBorderDragging(QMouseEvent *event) {
       setCursor(Qt::SizeFDiagCursor);
     } else if (rightBorderHit(globalMousePos) && topBorderHit(globalMousePos)) {
       setCursor(Qt::SizeBDiagCursor);
-    } else if (leftBorderHit(globalMousePos) &&
-               bottomBorderHit(globalMousePos)) {
+    } else if (leftBorderHit(globalMousePos) && bottomBorderHit(globalMousePos)) {
       setCursor(Qt::SizeBDiagCursor);
-    } else {
+    } else if (rightBorderHit(globalMousePos) && bottomBorderHit(globalMousePos)) {
+        setCursor(Qt::SizeFDiagCursor);
+    }else {
       if (topBorderHit(globalMousePos)) {
         setCursor(Qt::SizeVerCursor);
       } else if (leftBorderHit(globalMousePos)) {
@@ -397,7 +414,11 @@ void FramelessWindow::mousePressEvent(QMouseEvent *event) {
     m_bDragLeft = true;
     m_bDragBottom = true;
     setCursor(Qt::SizeBDiagCursor);
-  } else {
+  } else if (rightBorderHit(globalMousePos) && bottomBorderHit(globalMousePos)) {
+      m_bDragRight = true;
+      m_bDragBottom = true;
+      setCursor(Qt::SizeFDiagCursor);
+  }else {
     if (topBorderHit(globalMousePos)) {
       m_bDragTop = true;
       setCursor(Qt::SizeVerCursor);


### PR DESCRIPTION
fix: border can't resize when framelesswindows in a parent widget
fix:the FramelessWindow's bottom right corner can't drag